### PR TITLE
Feat/ipfs init

### DIFF
--- a/add-on/src/lib/ipfs-client/embedded.js
+++ b/add-on/src/lib/ipfs-client/embedded.js
@@ -1,22 +1,19 @@
 'use strict'
 
 const Ipfs = require('ipfs')
-const IpfsApi = require('ipfs-api')
 
 let node = null
 
 exports.init = function init () {
   console.log('[ipfs-companion] Embedded ipfs init')
 
-  const ipfsJs = new Ipfs({
+  node = new Ipfs({
     config: {
       Addresses: {
         Swarm: []
       }
     }
   })
-
-  node = createApiAdaptor(ipfsJs)
 
   if (node.isOnline()) {
     return Promise.resolve(node)
@@ -27,19 +24,6 @@ exports.init = function init () {
     node.once('error', (err) => reject(err))
     node.once('ready', () => resolve(node))
   })
-}
-
-// Create a minimal ipfsApi adaptor, so we can use an ipfsJs node in place of an ipfsApi.
-function createApiAdaptor (ipfs) {
-  const ipfsApiLite = new Proxy(ipfs, {
-    get: (ipfs, prop) => {
-      if (prop === 'Buffer') {
-        return IpfsApi.Buffer
-      }
-      return ipfs[prop]
-    }
-  })
-  return ipfsApiLite
 }
 
 exports.destroy = async function () {

--- a/add-on/src/lib/ipfs-client/embedded.js
+++ b/add-on/src/lib/ipfs-client/embedded.js
@@ -1,0 +1,48 @@
+const Ipfs = require('ipfs')
+const IpfsApi = require('ipfs-api')
+
+let node = null
+
+exports.init = function init () {
+  console.log('[ipfs-companion] Embedded ipfs init')
+
+  const ipfsJs = new Ipfs({
+    config: {
+      Addresses: {
+        Swarm: []
+      }
+    }
+  })
+
+  node = createApiAdaptor(ipfsJs)
+
+  if (node.isOnline()) {
+    return Promise.resolve(node)
+  }
+
+  return new Promise((resolve, reject) => {
+    // TODO: replace error listener after a 'ready' event.
+    node.once('error', (err) => reject(err))
+    node.once('ready', () => resolve(node))
+  })
+}
+
+// Create a minimal ipfsApi adaptor, so we can use an ipfsJs node in place of an ipfsApi.
+function createApiAdaptor (ipfs) {
+  const ipfsApiLite = new Proxy(ipfs, {
+    get: (ipfs, prop) => {
+      if (prop === 'Buffer') {
+        return IpfsApi.Buffer
+      }
+      return ipfs[prop]
+    }
+  })
+  return ipfsApiLite
+}
+
+exports.destroy = async function () {
+  if (!node) return
+
+  await node.stop()
+  node = null
+}

--- a/add-on/src/lib/ipfs-client/embedded.js
+++ b/add-on/src/lib/ipfs-client/embedded.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const Ipfs = require('ipfs')
 const IpfsApi = require('ipfs-api')
 

--- a/add-on/src/lib/ipfs-client/external.js
+++ b/add-on/src/lib/ipfs-client/external.js
@@ -1,0 +1,11 @@
+const IpfsApi = require('ipfs-api')
+
+exports.init = async function (opts) {
+  const url = new window.URL(opts.ipfsApiUrl)
+  const api = IpfsApi({host: url.hostname, port: url.port, procotol: url.protocol})
+  return api
+}
+
+exports.destroy = async function () {
+  return Promise.resolve()
+}

--- a/add-on/src/lib/ipfs-client/external.js
+++ b/add-on/src/lib/ipfs-client/external.js
@@ -1,11 +1,12 @@
+'use strict'
+/* eslint-env browser */
+
 const IpfsApi = require('ipfs-api')
 
 exports.init = async function (opts) {
-  const url = new window.URL(opts.ipfsApiUrl)
+  console.log('[ipfs-companion] External ipfs init')
+
+  const url = new URL(opts.ipfsApiUrl)
   const api = IpfsApi({host: url.hostname, port: url.port, procotol: url.protocol})
   return api
-}
-
-exports.destroy = async function () {
-  return Promise.resolve()
 }

--- a/add-on/src/lib/ipfs-client/index.js
+++ b/add-on/src/lib/ipfs-client/index.js
@@ -1,0 +1,14 @@
+const embedded = require('./embedded')
+const external = require('./external')
+
+let client = null
+
+exports.initIpfsClient = async function (opts) {
+  if (client) client.destroy()
+  if (opts.type === 'external') {
+    client = await external.init()
+  } else {
+    client = await embedded.init()
+  }
+  return client
+}

--- a/add-on/src/lib/ipfs-client/index.js
+++ b/add-on/src/lib/ipfs-client/index.js
@@ -1,14 +1,20 @@
+'use strict'
+
 const embedded = require('./embedded')
 const external = require('./external')
 
 let client = null
 
 exports.initIpfsClient = async function (opts) {
-  if (client) client.destroy()
-  if (opts.type === 'external') {
-    client = await external.init()
-  } else {
-    client = await embedded.init()
+  if (client && client.destroy) {
+    await client.destroy()
   }
+
+  if (opts.ipfsNodeType === 'embedded') {
+    client = await embedded.init(opts)
+  } else {
+    client = await external.init(opts)
+  }
+
   return client
 }

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -249,7 +249,7 @@ async function addFromURL (info) {
       const response = await fetch(srcUrl, fetchOptions)
       const reader = new FileReader()
       reader.onloadend = () => {
-        const buffer = ipfs.Buffer.from(reader.result)
+        const buffer = Buffer.from(reader.result)
         ipfs.add(buffer, uploadResultHandler)
       }
       reader.readAsArrayBuffer(await response.blob())

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -24,8 +24,8 @@ module.exports = async function init () {
     const options = await browser.storage.local.get(optionDefaults)
     state = window.state = initState(options)
 
-    ipfs = window.ipfs = await initIpfsClient(state)
-    console.log('[ipfs-companion] ipfs init complete', ipfs)
+    ipfs = window.ipfs = await initIpfsClient(options)
+    console.log('[ipfs-companion] ipfs init complete')
 
     // Check for ipfs dns txt records
     dnsLink = createDnsLink(getState)
@@ -590,7 +590,7 @@ function updateAutomaticModeRedirectState (oldPeerCount, newPeerCount) {
   }
 }
 
-function onStorageChange (changes, area) {
+async function onStorageChange (changes, area) {
   for (let key in changes) {
     let change = changes[key]
     if (change.oldValue !== change.newValue) {
@@ -599,7 +599,7 @@ function onStorageChange (changes, area) {
       if (key === 'ipfsApiUrl') {
         state.apiURL = new URL(change.newValue)
         state.apiURLString = state.apiURL.toString()
-        ipfs = window.ipfs = initIpfsClient(state)
+        ipfs = window.ipfs = await initIpfsClient(state)
         apiStatusUpdate()
       } else if (key === 'ipfsApiPollMs') {
         setApiStatusUpdateInterval(change.newValue)

--- a/add-on/src/lib/ipfs-companion.js
+++ b/add-on/src/lib/ipfs-companion.js
@@ -23,13 +23,9 @@ module.exports = async function init () {
   try {
     const options = await browser.storage.local.get(optionDefaults)
     state = window.state = initState(options)
-
     ipfs = window.ipfs = await initIpfsClient(options)
     console.log('[ipfs-companion] ipfs init complete')
-
-    // Check for ipfs dns txt records
     dnsLink = createDnsLink(getState)
-    // is it an ipfs path?
     ipfsPathValidator = createIpfsPathValidator(getState, dnsLink)
     modifyRequest = createRequestModifier(getState, dnsLink, ipfsPathValidator)
     registerListeners()

--- a/add-on/src/lib/options.js
+++ b/add-on/src/lib/options.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const optionDefaults = Object.freeze({
+  ipfsNodeType: 'external',
   publicGatewayUrl: 'https://ipfs.io',
   useCustomGateway: true,
   automaticMode: true,

--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -5,6 +5,7 @@ function initState (options) {
   const state = {}
   // we store the most used values in optimized form
   // to minimize performance impact on overall browsing experience
+  state.ipfsNodeType = 'external'
   state.pubGwURL = new URL(options.publicGatewayUrl)
   state.pubGwURLString = state.pubGwURL.toString()
   state.redirect = options.useCustomGateway

--- a/add-on/src/lib/state.js
+++ b/add-on/src/lib/state.js
@@ -5,7 +5,7 @@ function initState (options) {
   const state = {}
   // we store the most used values in optimized form
   // to minimize performance impact on overall browsing experience
-  state.ipfsNodeType = 'external'
+  state.ipfsNodeType = options.ipfsNodeType
   state.pubGwURL = new URL(options.publicGatewayUrl)
   state.pubGwURLString = state.pubGwURL.toString()
   state.redirect = options.useCustomGateway

--- a/add-on/src/popup/quick-upload.js
+++ b/add-on/src/popup/quick-upload.js
@@ -23,7 +23,7 @@ function quickUploadStore (state, emitter) {
       let reader = new FileReader()
       reader.onloadend = () => {
         const buffer = Buffer.from(reader.result)
-        bg.ipfs.add(buffer, (err, result) => {
+        bg.ipfs.files.add(buffer, (err, result) => {
           if (err || !result) {
             // keep upload tab and display error message in it
             state.message = `Unable to upload to IPFS API: ${err}`

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "build:copy": "run-s build:copy:*",
     "build:copy:src": "shx mkdir -p add-on/dist && shx cp -R add-on/src/* add-on/dist",
     "build:copy:wx-polyfill-lib": "shx cp node_modules/webextension-polyfill/dist/browser-polyfill.min.js add-on/dist/contentScripts/browser-polyfill.min.js",
-    "build:js": "browserify -t [ browserify-package-json --global ] add-on/src/background/background.js add-on/src/options/options.js add-on/src/popup/browser-action/index.js add-on/src/popup/quick-upload.js -p [ factor-bundle -o add-on/dist/background/background.js -o add-on/dist/options/options.js -o add-on/dist/popup/browser-action/browser-action.js -o add-on/dist/popup/quick-upload.js ] -o add-on/dist/ipfs-companion-common.js",
+    "build:js": "browserify -p prundupify -t [ browserify-package-json --global ] add-on/src/background/background.js add-on/src/options/options.js add-on/src/popup/browser-action/index.js add-on/src/popup/quick-upload.js -p [ factor-bundle -o add-on/dist/background/background.js -o add-on/dist/options/options.js -o add-on/dist/popup/browser-action/browser-action.js -o add-on/dist/popup/quick-upload.js ] -o add-on/dist/ipfs-companion-common.js",
     "build:minimize-dist": "shx rm -rf add-on/dist/lib",
     "build:bundle-extension": "web-ext build -s add-on/ -i src/ -a build/",
     "watch": "run-p watch:*",
-    "watch:js": "watchify add-on/src/background/background.js add-on/src/options/options.js add-on/src/popup/browser-action/index.js add-on/src/popup/quick-upload.js -p [ factor-bundle -o add-on/dist/background/background.js -o add-on/dist/options/options.js -o add-on/dist/popup/browser-action/browser-action.js -o add-on/dist/popup/quick-upload.js ] -o add-on/dist/ipfs-companion-common.js -v",
+    "watch:js": "watchify -p prundupify -t [ browserify-package-json --global ] add-on/src/background/background.js add-on/src/options/options.js add-on/src/popup/browser-action/index.js add-on/src/popup/quick-upload.js -p [ factor-bundle -o add-on/dist/background/background.js -o add-on/dist/options/options.js -o add-on/dist/popup/browser-action/browser-action.js -o add-on/dist/popup/quick-upload.js ] -o add-on/dist/ipfs-companion-common.js -v",
     "test": "run-s test:*",
     "test:functional": "mocha test/functional/**/*.test.js",
     "lint": "run-s lint:*",
@@ -68,9 +68,11 @@
   },
   "dependencies": {
     "choo": "6.6.0",
+    "ipfs": "^0.26.0",
     "ipfs-api": "17.1.3",
     "is-ipfs": "0.3.2",
     "lru_map": "0.3.3",
+    "prundupify": "^1.0.0",
     "webextension-polyfill": "0.1.2"
   }
 }


### PR DESCRIPTION
Sketching out a path to being able to swap between embedded and external ipfs _clients_

Wrap js-ipfs node in a Proxy where we can add and tweak behaviour as needed to create a common api that the rest of the app can use, without having to care how we talk to ipfs.

Fixes a bundling issue by adding `prundupify` as a browserify plugin... due to https://github.com/browserify/factor-bundle/issues/51 (factor-bundle and regular browserify de-duping don't play well together)